### PR TITLE
Relax activesupport dependency for padrino-helpers

### DIFF
--- a/json_factory.gemspec
+++ b/json_factory.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'activesupport', '>= 5.1.0'
+  spec.add_runtime_dependency 'activesupport'
   spec.add_runtime_dependency 'json'
   spec.add_runtime_dependency 'redis-activesupport', '>= 5.0.0'
 


### PR DESCRIPTION
Relaxes the activesupport dependency, in order to allow the use of padrino-helpers (which is still locked to activesupport 4 through the i18n gem). 